### PR TITLE
Wording tweaks in README, removal of gcc install step

### DIFF
--- a/.azure-ci/docker_scripts.sh
+++ b/.azure-ci/docker_scripts.sh
@@ -15,7 +15,7 @@ cd /io
 pip install -e ".[doc, tests]"
 
 # Test dev install with pytest and flake8
-pytest --cov . --cov-report xml
+pytest pyflagser --cov --cov-report xml
 flake8 --exit-zero /io/
 
 # Uninstal pyflagser dev

--- a/README.rst
+++ b/README.rst
@@ -91,12 +91,13 @@ You can check the latest sources with the command::
 To install:
 '''''''''''
 
+From the cloned repository's root directory, run
+
 .. code-block:: bash
 
-   cd pyflagser
    pip install -e .
 
-From there any change in the library files will be immediately available on your machine.
+This way, you can pull the library's latest changes and make them immediately available on your machine.
 
 Testing
 ~~~~~~~
@@ -104,7 +105,7 @@ Testing
 After installation, you can launch the test suite from outside the
 source directory::
 
-    pytest .
+    pytest pyflagser
 
 
 Changelog

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,12 +54,6 @@ jobs:
       versionSpec: '$(python.version)'
 
   - script: |
-      brew update
-      brew install gcc
-    failOnStderr: true
-    displayName: 'Install gcc'
-
-  - script: |
       python -m pip install --upgrade pip setuptools
     failOnStderr: true
     displayName: 'Upgrade pip and setuptools'
@@ -196,12 +190,6 @@ jobs:
   - task: UsePythonVersion@0
     inputs:
       versionSpec: '$(python.version)'
-
-  - script: |
-      brew update
-      brew install gcc
-    failOnStderr: true
-    displayName: 'Install gcc'
 
   - script: |
       python -m pip install --upgrade pip setuptools

--- a/pyflagser/flagio.py
+++ b/pyflagser/flagio.py
@@ -45,7 +45,7 @@ def loadflag(fname, fmt='csr', dtype=None):
 
 
 def saveflag(fname, flag_matrix):
-    """Save the matrix representation of a filtered flag complex into a 
+    """Save the matrix representation of a filtered flag complex into a
     ``.flag`` file.
 
     Parameters


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
The macOS VM images on Azure now seem to come shipped with `gcc` preinstalled. So it is no longer necessary to have a dedicated install step in `azure-pipelines.yml`