### PR TITLE
Add filtration support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,8 @@
 cmake_minimum_required(VERSION 3.9)
 project(flagser_pybind LANGUAGES CXX)
 
-find_package(pybind11 REQUIRED)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/pybind11)
+
 set(BINDINGS_DIR "src")
 
 find_package(OpenMP)

--- a/pyflagser/flagser.py
+++ b/pyflagser/flagser.py
@@ -6,7 +6,7 @@ from flagser_pybind import compute_homology
 
 
 def flagser(flag_matrix, min_dimension=0, max_dimension=np.inf, directed=True,
-            coeff=2, approximation=-1):
+            coeff=2, approximation=-1, filtration="max"):
     """Compute persistent homology of a directed/undirected
     weighted/unweighted flag complexes.
 
@@ -40,6 +40,17 @@ def flagser(flag_matrix, min_dimension=0, max_dimension=np.inf, directed=True,
         this number of entries. Use this for hard problems; a good value is
         often ``100,000``. Increase for higher precision, decrease for faster
         computation. A negative value computes highest possible precision.
+
+    filtration : string, optional, default: ``max``
+        filtration algorithm use the specified algorithm to compute the
+        filtration. Warning: if an edge filtration is specified, it is assumed
+        that the resulting filtration is consistent, meaning that the
+        filtration value of every simplex of dimension at least two should
+        evaluate to a value that is at least the maximal value of the
+        filtration values of its containing edges. For performance reasons,
+        this is not checked automatically. Possible values are = ['dimension',
+        'zero', 'max', 'max3', 'max_plus_one', 'product', 'sum', 'pmean',
+        'pmoment', 'remove_edges', 'vertex_degree']
 
     Returns
     -------
@@ -89,7 +100,7 @@ def flagser(flag_matrix, min_dimension=0, max_dimension=np.inf, directed=True,
         _max_dimension = max_dimension
 
     homology = compute_homology(vertices, edges, min_dimension, _max_dimension,
-                                directed, coeff, approximation)
+                                directed, coeff, approximation, filtration)
     # Creating dictionary of return values
     out = dict()
     out['dgms'] = homology[0].get_persistence_diagram()

--- a/pyflagser/flagser.py
+++ b/pyflagser/flagser.py
@@ -41,7 +41,7 @@ def flagser(flag_matrix, min_dimension=0, max_dimension=np.inf, directed=True,
         often ``100,000``. Increase for higher precision, decrease for faster
         computation. A negative value computes highest possible precision.
 
-    filtration : string, optional, default: `"max"`
+    filtration : string, optional, default: ``'max'``
         Algorithm determining the filtration. Warning: if an edge filtration is
         specified, it is assumed that the resulting filtration is consistent,
         meaning that the filtration value of every simplex of dimension at

--- a/pyflagser/flagser.py
+++ b/pyflagser/flagser.py
@@ -41,16 +41,15 @@ def flagser(flag_matrix, min_dimension=0, max_dimension=np.inf, directed=True,
         often ``100,000``. Increase for higher precision, decrease for faster
         computation. A negative value computes highest possible precision.
 
-    filtration : string, optional, default: ``max``
-        filtration algorithm use the specified algorithm to compute the
-        filtration. Warning: if an edge filtration is specified, it is assumed
-        that the resulting filtration is consistent, meaning that the
-        filtration value of every simplex of dimension at least two should
-        evaluate to a value that is at least the maximal value of the
-        filtration values of its containing edges. For performance reasons,
-        this is not checked automatically. Possible values are = ['dimension',
-        'zero', 'max', 'max3', 'max_plus_one', 'product', 'sum', 'pmean',
-        'pmoment', 'remove_edges', 'vertex_degree']
+    filtration : string, optional, default: `'max'`
+        Algorithm determining the filtration. Warning: if an edge filtration is
+        specified, it is assumed that the resulting filtration is consistent,
+        meaning that the filtration value of every simplex of dimension at
+        least two should evaluate to a value that is at least the maximal value
+        of the filtration values of its containing edges. For performance
+        reasons, this is not checked automatically.  Possible values are:
+        ['dimension', 'zero', 'max', 'max3', 'max_plus_one', 'product', 'sum',
+        'pmean', 'pmoment', 'remove_edges', 'vertex_degree']
 
     Returns
     -------

--- a/pyflagser/flagser.py
+++ b/pyflagser/flagser.py
@@ -99,7 +99,7 @@ def flagser(flag_matrix, min_dimension=0, max_dimension=np.inf, directed=True,
         _max_dimension = max_dimension
 
     if filtration not in implemented_filtrations:
-        print('unrecognized {}, using max'.format(filtration))
+        print('Unrecognized {} filtration, using max'.format(filtration))
         print('Available algorithms : {}'.format(implemented_filtrations))
         filtration = "max"
 

--- a/pyflagser/flagser.py
+++ b/pyflagser/flagser.py
@@ -41,7 +41,7 @@ def flagser(flag_matrix, min_dimension=0, max_dimension=np.inf, directed=True,
         often ``100,000``. Increase for higher precision, decrease for faster
         computation. A negative value computes highest possible precision.
 
-    filtration : string, optional, default: `'max'`
+    filtration : string, optional, default: `"max"`
         Algorithm determining the filtration. Warning: if an edge filtration is
         specified, it is assumed that the resulting filtration is consistent,
         meaning that the filtration value of every simplex of dimension at

--- a/pyflagser/flagser.py
+++ b/pyflagser/flagser.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 import scipy.sparse as sp
-from flagser_pybind import compute_homology
+from flagser_pybind import compute_homology, implemented_filtrations
 
 
 def flagser(flag_matrix, min_dimension=0, max_dimension=np.inf, directed=True,
@@ -98,6 +98,11 @@ def flagser(flag_matrix, min_dimension=0, max_dimension=np.inf, directed=True,
         _max_dimension = -1
     else:
         _max_dimension = max_dimension
+
+    if filtration not in implemented_filtrations:
+        print('unrecognized {}, using max'.format(filtration))
+        print('Available algorithms : {}'.format(implemented_filtrations))
+        filtration = "max"
 
     homology = compute_homology(vertices, edges, min_dimension, _max_dimension,
                                 directed, coeff, approximation, filtration)

--- a/setup.py
+++ b/setup.py
@@ -98,25 +98,6 @@ class CMakeBuild(build_ext):
         subprocess.check_call(['git', 'clone',
                                'https://github.com/pybind/pybind11.git',
                                dir_pybind11])
-        os.chdir(dir_pybind11)
-        dir_build = os.path.join(dir_pybind11, 'build')
-        os.mkdir(dir_build)
-        os.chdir(dir_build)
-        cmake_cmd1 = ['cmake', '-DPYBIND11_TEST=OFF', '..']
-        if platform.system() == "Windows":
-            cmake_cmd2 = ['cmake', '--install', '.']
-            if sys.maxsize > 2**32:
-                cmake_cmd1 += ['-A', 'x64']
-        else:
-            cmake_cmd2 = ['make', 'install']
-            cmake_cmd2_sudo = ['sudo', 'make', 'install']
-        subprocess.check_call(cmake_cmd1, cwd=dir_build)
-        try:
-            subprocess.check_call(cmake_cmd2, cwd=dir_build)
-        except: # noqa
-            subprocess.check_call(cmake_cmd2_sudo, cwd=dir_build)
-        os.chdir(dir_start)
-
         subprocess.check_call(['git', 'submodule', 'update',
                                '--init', '--recursive'])
 

--- a/src/flagser_bindings.cpp
+++ b/src/flagser_bindings.cpp
@@ -126,5 +126,7 @@ PYBIND11_MODULE(flagser_pybind, m) {
     return ret;
   });
 
+  m.attr("implemented_filtrations") = custom_filtration_computer;
+
   m.doc() = "Python bindings for flagser";
 }

--- a/src/flagser_bindings.cpp
+++ b/src/flagser_bindings.cpp
@@ -63,7 +63,7 @@ PYBIND11_MODULE(flagser_pybind, m) {
     named_arguments["--max-dim"] = std::to_string(effective_max_dim).c_str();
     named_arguments["--min-dim"] = std::to_string(min_dim).c_str();
 
-    // Is filstration supported ?
+    // Is filtration supported ?
     if (std::find(custom_filtration_computer.begin(),
                   custom_filtration_computer.end(),
                   filtration) == custom_filtration_computer.end()) {

--- a/src/flagser_bindings.cpp
+++ b/src/flagser_bindings.cpp
@@ -41,6 +41,8 @@ PYBIND11_MODULE(flagser_pybind, m) {
                                bool directed, coefficient_t modulus,
                                signed int approximation,
                                std::string filtration) {
+    // Save std::cout status
+    auto cout_buff = std::cout.rdbuf();
 
     HAS_EDGE_FILTRATION has_edge_filtration =
         HAS_EDGE_FILTRATION::TOO_EARLY_TO_DECIDE;
@@ -117,6 +119,9 @@ PYBIND11_MODULE(flagser_pybind, m) {
 
     if (remove(named_arguments["out"]) != 0)
       perror("Error deleting flagser output file");
+
+    // re enable again cout
+    std::cout.rdbuf(cout_buff);
 
     return ret;
   });

--- a/src/flagser_bindings.cpp
+++ b/src/flagser_bindings.cpp
@@ -6,9 +6,10 @@
 #include <iostream>
 
 #include <flagser/include/argparser.h>
+#include <flagser/src/flagser.cpp>
+
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
-#include <flagser/src/flagser.cpp>
 
 namespace py = pybind11;
 
@@ -38,23 +39,46 @@ PYBIND11_MODULE(flagser_pybind, m) {
                                std::vector<std::vector<value_t>>& edges,
                                unsigned short min_dim, short max_dim,
                                bool directed, coefficient_t modulus,
-                               signed int approximation) {
+                               signed int approximation,
+                               std::string filtration) {
+
     HAS_EDGE_FILTRATION has_edge_filtration =
         HAS_EDGE_FILTRATION::TOO_EARLY_TO_DECIDE;
 
     // Approximation should only be a positive value
     // Otherwise it falls back to type::numeric_limits
-    size_t max_entries = approximation >= 0
-                             ? approximation
-                             : std::numeric_limits<size_t>::max();
+    size_t max_entries =
+        approximation >= 0 ? approximation : std::numeric_limits<size_t>::max();
 
     unsigned short effective_max_dim = max_dim;
-    if(max_dim < 0) effective_max_dim = std::numeric_limits<unsigned short>::max();
+    std::string default_filtration = "max";
+
+    if (max_dim < 0)
+      effective_max_dim = std::numeric_limits<unsigned short>::max();
 
     named_arguments_t named_arguments;
     named_arguments["out"] = "output_flagser_file";
     named_arguments["--max-dim"] = std::to_string(effective_max_dim).c_str();
     named_arguments["--min-dim"] = std::to_string(min_dim).c_str();
+
+    // Is filstration supported ?
+    if (std::find(custom_filtration_computer.begin(),
+                  custom_filtration_computer.end(),
+                  filtration) == custom_filtration_computer.end()) {
+      std::cout << filtration << " not found, fallback to "
+                << default_filtration << "\n";
+      filtration = default_filtration;
+
+      std::cout << "Implemented filtrations:\n";
+      for (auto& elem : custom_filtration_computer) {
+        if (elem != custom_filtration_computer.back())
+          std::cout << elem << ", ";
+        else
+          std::cout << elem << "\n";
+      }
+    }
+
+    named_arguments["--filtration"] = filtration.c_str();
 
     remove(named_arguments["out"]);
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/giotto-ai/pyflagser/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#16 

#### What does this implement/fix? Explain your changes.

* Implements support for the different filtrations supported by `flagser`
* Fix disabling of std::cout which was disabled until the programs ends :cry: 
* Clean setup.py unnecessary  installation of pybind11

#### Any other comments?

Add check of filtration if both bindings and python code for available filtrations.

<!--
We value all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
