### PR TITLE
Enable flagser_count capabilities from C++ flagser and have two modules to handle coeff = or != 2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,3 +25,19 @@ else()
     target_compile_options(flagser_pybind PUBLIC $<$<CONFIG:RELEASE>: -Ofast>)
     target_compile_options(flagser_pybind PUBLIC $<$<CONFIG:DEBUG>: -O2 -ggdb -D_GLIBCXX_DEBUG>)
 endif()
+
+pybind11_add_module(flagser_count_pybind "${BINDINGS_DIR}/flagser_count_bindings.cpp")
+
+if(OpenMP_FOUND)
+  target_link_libraries(flagser_count_pybind PRIVATE OpenMP::OpenMP_CXX)
+endif()
+
+target_include_directories(flagser_count_pybind PRIVATE .)
+
+if(MSVC)
+    target_compile_options(flagser_count_pybind PUBLIC $<$<CONFIG:RELEASE>: /Wall /O2>)
+    target_compile_options(flagser_count_pybind PUBLIC $<$<CONFIG:DEBUG>:/O1 /DEBUG:FULL /Zi /Zo>)
+else()
+    target_compile_options(flagser_count_pybind PUBLIC $<$<CONFIG:RELEASE>: -Ofast>)
+    target_compile_options(flagser_count_pybind PUBLIC $<$<CONFIG:DEBUG>: -O2 -ggdb -D_GLIBCXX_DEBUG>)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,16 +7,14 @@ add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/pybind11)
 
 set(BINDINGS_DIR "src")
 
-find_package(OpenMP)
+find_package(Threads REQUIRED)
 
+# flagser
 pybind11_add_module(flagser_pybind "${BINDINGS_DIR}/flagser_bindings.cpp")
-
-if(OpenMP_FOUND)
-  target_link_libraries(flagser_pybind PRIVATE OpenMP::OpenMP_CXX)
-endif()
 
 target_compile_definitions(flagser_pybind PRIVATE RETRIEVE_PERSISTENCE=1)
 target_include_directories(flagser_pybind PRIVATE .)
+target_link_libraries(flagser_pybind PRIVATE pthread)
 
 if(MSVC)
     target_compile_options(flagser_pybind PUBLIC $<$<CONFIG:RELEASE>: /Wall /O2>)
@@ -26,13 +24,27 @@ else()
     target_compile_options(flagser_pybind PUBLIC $<$<CONFIG:DEBUG>: -O2 -ggdb -D_GLIBCXX_DEBUG>)
 endif()
 
-pybind11_add_module(flagser_count_pybind "${BINDINGS_DIR}/flagser_count_bindings.cpp")
+# flagser with USE_COEFFICIENTS
+pybind11_add_module(flagser_coeff_pybind "${BINDINGS_DIR}/flagser_bindings.cpp")
 
-if(OpenMP_FOUND)
-  target_link_libraries(flagser_count_pybind PRIVATE OpenMP::OpenMP_CXX)
+target_compile_definitions(flagser_coeff_pybind PRIVATE RETRIEVE_PERSISTENCE=1 USE_COEFFICIENTS=1)
+target_include_directories(flagser_coeff_pybind PRIVATE .)
+target_link_libraries(flagser_coeff_pybind PRIVATE pthread)
+
+if(MSVC)
+    target_compile_options(flagser_coeff_pybind PUBLIC $<$<CONFIG:RELEASE>: /Wall /O2>)
+    target_compile_options(flagser_coeff_pybind PUBLIC $<$<CONFIG:DEBUG>:/O1 /DEBUG:FULL /Zi /Zo>)
+else()
+    target_compile_options(flagser_coeff_pybind PUBLIC $<$<CONFIG:RELEASE>: -Ofast>)
+    target_compile_options(flagser_coeff_pybind PUBLIC $<$<CONFIG:DEBUG>: -O2 -ggdb -D_GLIBCXX_DEBUG>)
 endif()
 
+
+# flagser-count
+pybind11_add_module(flagser_count_pybind "${BINDINGS_DIR}/flagser_count_bindings.cpp")
+
 target_include_directories(flagser_count_pybind PRIVATE .)
+target_link_libraries(flagser_count_pybind PRIVATE pthread)
 
 if(MSVC)
     target_compile_options(flagser_count_pybind PUBLIC $<$<CONFIG:RELEASE>: /Wall /O2>)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,14 +7,11 @@ add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/pybind11)
 
 set(BINDINGS_DIR "src")
 
-find_package(Threads REQUIRED)
-
 # flagser
 pybind11_add_module(flagser_pybind "${BINDINGS_DIR}/flagser_bindings.cpp")
 
 target_compile_definitions(flagser_pybind PRIVATE RETRIEVE_PERSISTENCE=1)
 target_include_directories(flagser_pybind PRIVATE .)
-target_link_libraries(flagser_pybind PRIVATE pthread)
 
 if(MSVC)
     target_compile_options(flagser_pybind PUBLIC $<$<CONFIG:RELEASE>: /Wall /O2>)
@@ -29,7 +26,6 @@ pybind11_add_module(flagser_coeff_pybind "${BINDINGS_DIR}/flagser_bindings.cpp")
 
 target_compile_definitions(flagser_coeff_pybind PRIVATE RETRIEVE_PERSISTENCE=1 USE_COEFFICIENTS=1)
 target_include_directories(flagser_coeff_pybind PRIVATE .)
-target_link_libraries(flagser_coeff_pybind PRIVATE pthread)
 
 if(MSVC)
     target_compile_options(flagser_coeff_pybind PUBLIC $<$<CONFIG:RELEASE>: /Wall /O2>)
@@ -44,7 +40,6 @@ endif()
 pybind11_add_module(flagser_count_pybind "${BINDINGS_DIR}/flagser_count_bindings.cpp")
 
 target_include_directories(flagser_count_pybind PRIVATE .)
-target_link_libraries(flagser_count_pybind PRIVATE pthread)
 
 if(MSVC)
     target_compile_options(flagser_count_pybind PUBLIC $<$<CONFIG:RELEASE>: /Wall /O2>)

--- a/pyflagser/__init__.py
+++ b/pyflagser/__init__.py
@@ -3,8 +3,15 @@ from ._version import __version__
 from .flagio import load_unweighted_flag, load_weighted_flag, \
     save_unweighted_flag, save_weighted_flag
 from .flagser import flagser_unweighted, flagser_weighted
+from .flagser_count import flagser_count_unweighted, \
+    flagser_count_weighted
 
-__all__ = ['load_unweighted_flag', 'load_weighted_flag',
-           'save_unweighted_flag', 'save_weighted_flag',
-           'flagser_unweighted', 'flagser_weighted',
+__all__ = ['load_unweighted_flag',
+           'load_weighted_flag',
+           'save_unweighted_flag',
+           'save_weighted_flag',
+           'flagser_unweighted',
+           'flagser_weighted',
+           'flagser_count_unweighted',
+           'flagser_count_weighted',
            '__version__']

--- a/pyflagser/flagser.py
+++ b/pyflagser/flagser.py
@@ -154,12 +154,13 @@ def flagser_weighted(adjacency_matrix, max_edge_weight=None, min_dimension=0,
         flag complex determined by `adjacency_matrix`. If ``False``, computes
         persistent homology for the undirected filtered flag complex obtained
         by considering all weighted edges as undirected, and if two directed
-        edges corresponding to the same undirected edge are assigned different
-        weights, only the one on the upper triangular part of the adjacency
-        matrix is considered. Therefore:
+        edges corresponding to the same undirected edge are explicitly assigned
+        different weights and neither exceeds `max_edge_weight`, only the one
+        in the upper triangular part of the adjacency matrix is considered.
+        Therefore:
 
         - if `max_edge_weight` is ``numpy.inf``, it is sufficient to pass a
-          (dense or sparse) upper-triangular matrices;
+          (dense or sparse) upper-triangular matrix;
         - if `max_edge_weight` is finite, it is recommended to pass either a
           symmetric dense matrix, or a sparse upper-triangular matrix.
 

--- a/pyflagser/flagser.py
+++ b/pyflagser/flagser.py
@@ -31,11 +31,18 @@ def flagser_unweighted(adjacency_matrix, min_dimension=0, max_dimension=np.inf,
         Maximum homology dimension to compute.
 
     directed : bool, optional, default: ``True``
-        If ``True``, computes homology for the directed flad complex determined
-        by `adjacency_matrix`. If ``False``, computes homology for the
-        undirected flag complex obtained by considering all edges as
-        undirected, and it is therefore sufficient (but not necessary)
-        to pass an upper-triangular matrix.
+        If ``True``, computes persistent homology for the directed filtered
+        flag complex determined by `adjacency_matrix`. If ``False``, computes
+        persistent homology for the undirected filtered flag complex obtained
+        by considering all weighted edges as undirected, and if two directed
+        edges corresponding to the same undirected edge are assigned different
+        weights, only the one on the upper triangular part of the adjacency
+        matrix is considered. Therefore:
+
+        - if `max_edge_weight` is ``numpy.inf``, it is sufficient to pass a
+          (dense or sparse) upper-triangular matrices;
+        - if `max_edge_weight` is finite, it is recommended to pass either a
+          symmetric dense matrix, or a sparse upper-triangular matrix.
 
     coeff : int, optional, default: ``2``
         Compute homology with coefficients in the prime field

--- a/pyflagser/flagser.py
+++ b/pyflagser/flagser.py
@@ -100,8 +100,9 @@ def flagser_unweighted(adjacency_matrix, min_dimension=0, max_dimension=np.inf,
         _compute_homology = compute_homology_coeff
 
     # Call flagser binding
-    homology = _compute_homology(vertices, edges, min_dimension, _max_dimension,
-                                directed, coeff, _approximation, _filtration)
+    homology = _compute_homology(vertices, edges, min_dimension,
+                                 _max_dimension, directed, coeff,
+                                 _approximation, _filtration)
 
     # Creating dictionary of return values
     out = dict()
@@ -225,7 +226,7 @@ def flagser_weighted(adjacency_matrix, max_edge_weight=None, min_dimension=0,
     else:
         _approximation = approximation
 
-    if filtration not in implemented_filtrations:
+    if filtration not in AVAILABLE_FILTRATIONS:
         raise ValueError("Filtration not recognized. Available filtrations "
                          "are ", AVAILABLE_FILTRATIONS)
 

--- a/pyflagser/flagser.py
+++ b/pyflagser/flagser.py
@@ -55,11 +55,11 @@ def flagser_unweighted(adjacency_matrix, min_dimension=0, max_dimension=np.inf,
         A dictionary with the following key-value pairs:
 
         - ``'betti'``: list of int
-          Betti number per dimension greater than or equal than
+          Betti numbers, per dimension greater than or equal than
           `min_dimension` and less than `max_dimension`.
         - ``'cell_count'``: list of int
-          Cell count (number of simplices) per dimension greater than or equal
-          `min_dimension` and less than `max_dimension`.
+          Cell counts (number of simplices), per dimension greater than or equal
+          to `min_dimension` and less than `max_dimension`.
         - ``'euler'``: int
           Euler characteristic.
 
@@ -193,12 +193,12 @@ def flagser_weighted(adjacency_matrix, max_edge_weight=None, min_dimension=0,
           column representing the birth time and the second column
           representing the death time of each pair.
         - ``'betti'``: list of int
-          Betti number at filtration value `max_edge_weight` per dimension
-          greater than or equal than `min_dimension` and less than
+          Betti numbers at filtration value `max_edge_weight`, per dimension
+          greater than or equal to `min_dimension` and less than
           `max_dimension`.
         - ``'cell_count'``: list of int
-          Cell count (number of simplices) at filtration value
-          `max_edge_weight` per dimension greater than or equal than
+          Cell counts (number of simplices) at filtration value
+          `max_edge_weight`, per dimension greater than or equal to
           `min_dimension` and less than `max_dimension`.
         - ``'euler'``: int
           Euler characteristic at filtration value `max_edge_weight`.

--- a/pyflagser/flagser.py
+++ b/pyflagser/flagser.py
@@ -241,7 +241,8 @@ def flagser_weighted(adjacency_matrix, max_edge_weight=None, min_dimension=0,
 
     # Create dictionary of return values
     out = {
-        'dgms': [np.asarray(d) for d in homology.get_persistence_diagram()],
+        'dgms': [np.asarray(d).reshape((-1, 2))
+                 for d in homology.get_persistence_diagram()],
         'betti': homology.get_betti_numbers(),
         'cell_count': homology.get_cell_count(),
         'euler': homology.get_euler_characteristic()

--- a/pyflagser/flagser.py
+++ b/pyflagser/flagser.py
@@ -102,7 +102,7 @@ def flagser_unweighted(adjacency_matrix, min_dimension=0, max_dimension=np.inf,
     # Call flagser binding
     homology = _compute_homology(vertices, edges, min_dimension,
                                  _max_dimension, directed, coeff,
-                                 _approximation, _filtration)
+                                 _approximation, _filtration)[0]
 
     # Creating dictionary of return values
     out = {

--- a/pyflagser/flagser.py
+++ b/pyflagser/flagser.py
@@ -3,7 +3,9 @@
 import numpy as np
 
 from ._utils import _extract_unweighted_graph, _extract_weighted_graph
-from flagser_pybind import compute_homology, implemented_filtrations
+from .modules.flagser_pybind import compute_homology, AVAILABLE_FILTRATIONS
+from .modules.flagser_coeff_pybind import compute_homology as \
+    compute_homology_coeff
 
 
 def flagser_unweighted(adjacency_matrix, min_dimension=0, max_dimension=np.inf,
@@ -91,8 +93,14 @@ def flagser_unweighted(adjacency_matrix, min_dimension=0, max_dimension=np.inf,
     # Extract vertices and edges
     vertices, edges = _extract_unweighted_graph(adjacency_matrix)
 
+    # Select the homology computer based on coeff
+    if coeff == 2:
+        _compute_homology = compute_homology
+    else:
+        _compute_homology = compute_homology_coeff
+
     # Call flagser binding
-    homology = compute_homology(vertices, edges, min_dimension, _max_dimension,
+    homology = _compute_homology(vertices, edges, min_dimension, _max_dimension,
                                 directed, coeff, _approximation, _filtration)
 
     # Creating dictionary of return values
@@ -219,7 +227,7 @@ def flagser_weighted(adjacency_matrix, max_edge_weight=None, min_dimension=0,
 
     if filtration not in implemented_filtrations:
         raise ValueError("Filtration not recognized. Available filtrations "
-                         "are ", implemented_filtrations)
+                         "are ", AVAILABLE_FILTRATIONS)
 
     # Extract vertices and edges weights
     vertices, edges = _extract_weighted_graph(adjacency_matrix,

--- a/pyflagser/flagser.py
+++ b/pyflagser/flagser.py
@@ -58,8 +58,8 @@ def flagser_unweighted(adjacency_matrix, min_dimension=0, max_dimension=np.inf,
           Betti numbers, per dimension greater than or equal than
           `min_dimension` and less than `max_dimension`.
         - ``'cell_count'``: list of int
-          Cell counts (number of simplices), per dimension greater than or equal
-          to `min_dimension` and less than `max_dimension`.
+          Cell counts (number of simplices), per dimension greater than or
+          equal to `min_dimension` and less than `max_dimension`.
         - ``'euler'``: int
           Euler characteristic.
 

--- a/pyflagser/flagser.py
+++ b/pyflagser/flagser.py
@@ -31,18 +31,11 @@ def flagser_unweighted(adjacency_matrix, min_dimension=0, max_dimension=np.inf,
         Maximum homology dimension to compute.
 
     directed : bool, optional, default: ``True``
-        If ``True``, computes persistent homology for the directed filtered
-        flag complex determined by `adjacency_matrix`. If ``False``, computes
-        persistent homology for the undirected filtered flag complex obtained
-        by considering all weighted edges as undirected, and if two directed
-        edges corresponding to the same undirected edge are assigned different
-        weights, only the one on the upper triangular part of the adjacency
-        matrix is considered. Therefore:
-
-        - if `max_edge_weight` is ``numpy.inf``, it is sufficient to pass a
-          (dense or sparse) upper-triangular matrices;
-        - if `max_edge_weight` is finite, it is recommended to pass either a
-          symmetric dense matrix, or a sparse upper-triangular matrix.
+        If ``True``, computes homology for the directed flad complex determined
+        by `adjacency_matrix`. If ``False``, computes homology for the
+        undirected flag complex obtained by considering all edges as
+        undirected, and it is therefore sufficient (but not necessary)
+        to pass an upper-triangular matrix.
 
     coeff : int, optional, default: ``2``
         Compute homology with coefficients in the prime field
@@ -158,13 +151,17 @@ def flagser_weighted(adjacency_matrix, max_edge_weight=None, min_dimension=0,
 
     directed : bool, optional, default: ``True``
         If ``True``, computes persistent homology for the directed filtered
-        flag complex determined by `adjacency_matrix`. If False, computes
+        flag complex determined by `adjacency_matrix`. If ``False``, computes
         persistent homology for the undirected filtered flag complex obtained
-        by considering all weighted edges as undirected, and it is therefore
-        sufficient (but not necessary) to pass an upper-triangular matrix. When
-        ``False``, if two directed edges corresponding to the same undirected
-        edge are assigned different weights, only the one on the upper
-        triangular part of the adjacency matrix is considered.
+        by considering all weighted edges as undirected, and if two directed
+        edges corresponding to the same undirected edge are assigned different
+        weights, only the one on the upper triangular part of the adjacency
+        matrix is considered. Therefore:
+
+        - if `max_edge_weight` is ``numpy.inf``, it is sufficient to pass a
+          (dense or sparse) upper-triangular matrices;
+        - if `max_edge_weight` is finite, it is recommended to pass either a
+          symmetric dense matrix, or a sparse upper-triangular matrix.
 
     filtration : string, optional, default: ``'max'``
         Algorithm determining the filtration. Warning: if an edge filtration is
@@ -242,9 +239,16 @@ def flagser_weighted(adjacency_matrix, max_edge_weight=None, min_dimension=0,
     vertices, edges = _extract_weighted_graph(adjacency_matrix,
                                               max_edge_weight)
 
+    # Select the homology computer based on coeff
+    if coeff == 2:
+        _compute_homology = compute_homology
+    else:
+        _compute_homology = compute_homology_coeff
+
     # Call flagser binding
-    homology = compute_homology(vertices, edges, min_dimension, _max_dimension,
-                                directed, coeff, _approximation, filtration)[0]
+    homology = _compute_homology(vertices, edges, min_dimension,
+                                 _max_dimension, directed, coeff,
+                                 _approximation, filtration)[0]
 
     # Create dictionary of return values
     out = {

--- a/pyflagser/flagser_count.py
+++ b/pyflagser/flagser_count.py
@@ -4,8 +4,7 @@ library."""
 import numpy as np
 
 from ._utils import _extract_unweighted_graph, _extract_weighted_graph
-from flagser_pybind import implemented_filtrations
-from flagser_count_pybind import compute_cell_count
+from .modules.flagser_count_pybind import compute_cell_count
 
 
 def flagser_count_unweighted(adjacency_matrix, min_dimension=0,

--- a/pyflagser/flagser_count.py
+++ b/pyflagser/flagser_count.py
@@ -101,8 +101,8 @@ def flagser_count_weighted(adjacency_matrix, max_edge_weight=None,
     Returns
     -------
     out : list of int
-        Cell counts (number of simplices) at filtration value `max_edge_weight`,
-        per dimension.
+        Cell counts (number of simplices) at filtration value
+        `max_edge_weight`, per dimension.
 
     Notes
     -----

--- a/pyflagser/flagser_count.py
+++ b/pyflagser/flagser_count.py
@@ -12,7 +12,7 @@ def flagser_count_unweighted(adjacency_matrix, min_dimension=0,
     """Compute the cell count per dimension of a directed/undirected unweighted
     flag complex.
 
-    From an adjacency_matrix construct all cells forming its associated flag
+    From an adjacency matrix construct all cells forming its associated flag
     complex and compute their number per dimension.
 
     Parameters
@@ -59,15 +59,14 @@ def flagser_count_unweighted(adjacency_matrix, min_dimension=0,
     return cell_count
 
 
-def flagser_count_weighted(adjacency_matrix, max_edge_length=None,
-                           min_dimension=0, max_dimension=np.inf,
-                           directed=True, filtration="max"):
+def flagser_count_weighted(adjacency_matrix, max_edge_weight=None,
+                           directed=True):
     """Compute the cell count per dimension of a directed/undirected
-    filtered flag complexes.
+    filtered flag complex.
 
-    From an adjacency_matrix construct a filtered flag complex as a sequence of
+    From an adjacency matrix construct a filtered flag complex as a sequence of
     its cells associated to their filtration values and compute the number of
-    cells per dimension.
+    cells per dimension at the end of the filtration.
 
     Parameters
     ----------
@@ -119,7 +118,7 @@ def flagser_count_weighted(adjacency_matrix, max_edge_length=None,
     """
     # Extract vertices and edges weights
     vertices, edges = _extract_weighted_graph(adjacency_matrix,
-                                              max_edge_length)
+                                              max_edge_weight)
 
     # Call flagser_count binding
     cell_count = compute_cell_count(vertices, edges, directed)

--- a/pyflagser/flagser_count.py
+++ b/pyflagser/flagser_count.py
@@ -1,0 +1,168 @@
+"""Implementation of the python API for the cell count of the flagser C++
+library."""
+
+import numpy as np
+
+from ._utils import _extract_unweighted_graph, _extract_weighted_graph
+from flagser_pybind import implemented_filtrations
+from flagser_count_pybind import compute_cell_count
+
+
+def flagser_count_unweighted(adjacency_matrix, min_dimension=0,
+                             max_dimension=np.inf, directed=True):
+    """Compute the cell count per dimension of a directed/undirected unweighted
+    flag complex.
+
+    From an adjacency_matrix construct all cells forming its associated flag
+    complex and count their number per dimension.
+
+    Parameters
+    ----------
+    adjacency_matrix : 2d ndarray or scipy.sparse matrix of shape \
+        (n_vertices, n_vertices), required
+        Adjacency matrix of a directed/undirected unweighted graph. It is
+        understood as a boolean matrix. Off-diagonal, ``0`` or ``False`` values
+        denote abstent edges while non-``0`` or ``True`` values denote edges
+        which are present. Diagonal values are ignored.
+
+    min_dimension : int, optional, default: ``0``
+        Minimum cell dimension to count.
+
+    max_dimension : int or np.inf, optional, default: ``np.inf``
+        Maximum cell dimension to count.
+
+    directed : bool, optional, default: ``True``
+        If ``True``, computes homology for the directed flad complex determined
+        by `adjacency_matrix`. If ``False``, computes homology for the
+        undirected flag complex obtained by considering all edges as
+        undirected, and it is therefore sufficient (but not necessary)
+        to pass an upper-triangular matrix.
+
+    Returns
+    -------
+    out : list of int
+        Cell count (number of simplices) per dimension greater than or equal
+        than `min_dimension` and less than `max_dimension`.
+
+    Notes
+    -----
+    The input graphs cannot contain self-loops, i.e. edges that start and end
+    in the same vertex, therefore diagonal elements of the input adjacency
+    matrix will be ignored.
+
+    References
+    ----------
+    .. [1] D. Luetgehetmann, "Documentation of the C++ flagser library";
+           `GitHub: luetge/flagser <https://github.com/luetge/flagser/blob/\
+           master/docs/documentation_flagser.pdf>`_.
+
+    """
+    # Handle default parameters
+    if max_dimension == np.inf:
+        _max_dimension = -1
+    else:
+        _max_dimension = max_dimension
+
+    # All edge filtrations are equivalent in the static case
+    _filtration = 'max'
+
+    # Extract vertices and edges
+    vertices, edges = _extract_unweighted_graph(adjacency_matrix)
+
+    # Call flagser_count binding
+    cell_count = compute_cell_count(vertices, edges, min_dimension,
+                                    _max_dimension,  directed, _filtration)
+
+    return cell_count[min_dimension:]
+
+
+def flagser_count_weighted(adjacency_matrix, max_edge_length=None,
+                           min_dimension=0, max_dimension=np.inf,
+                           directed=True, filtration="max"):
+    """Compute the cell count per dimension of a directed/undirected
+    weighted/unweighted flag complexes.
+
+    Parameters
+    ----------
+    adjacency_matrix : 2d ndarray or scipy.sparse matrix of shape \
+        (n_vertices, n_vertices), required
+        Matrix representation of a directed/undirected weighted graph. Diagonal
+        elements are vertex weights. The way zero values are handled depends on
+        the format of the matrix. If the matrix is a dense ``numpy.ndarray``,
+        zero values denote zero-weighted edges. If the matrix is a sparse
+        ``scipy.sparse`` matrix, explicitly stored off-diagonal zeros and all
+        diagonal zeros denote zero-weighted edges. Off-diagonal values that
+        have not been explicitely stored are treated by ``scipy.sparse`` as
+        zeros but will be understood as infinitely-valued edges, i.e., edges
+        absent from the filtration.
+
+    max_edge_weight : int or float or ``None``, optional, default: ``None``
+        Maximum edge weight to be considered in the filtration. All edge
+        weights greater than that value will be considered as
+        infinitely-valued, i.e., absent from the filtration. If ``None``, all
+        finite edge weights are considered.
+
+    min_dimension : int, optional, default: ``0``
+        Minimum cell dimension to count.
+
+    max_dimension : int or np.inf, optional, default: ``np.inf``
+        Maximum cell dimension to count.
+
+    directed : bool, optional, default: ``True``
+        If ``True``, computes persistent homology for the directed filtered
+        flag complex determined by `adjacency_matrix`. If False, computes
+        persistent homology for the undirected filtered flag complex obtained
+        by considering all weighted edges as undirected, and it is therefore
+        sufficient (but not necessary) to pass an upper-triangular matrix. When
+        ``False``, if two directed edges corresponding to the same undirected
+        edge are assigned different weights, only the one on the upper
+        triangular part of the adjacency matrix is considered.
+
+    filtration : string, optional, default: ``'max'``
+        Algorithm determining the filtration. Warning: if an edge filtration is
+        specified, it is assumed that the resulting filtration is consistent,
+        meaning that the filtration value of every simplex of dimension at
+        least two should evaluate to a value that is at least the maximal value
+        of the filtration values of its containing edges. For performance
+        reasons, this is not checked automatically.  Possible values are:
+        ['dimension', 'zero', 'max', 'max3', 'max_plus_one', 'product', 'sum',
+        'pmean', 'pmoment', 'remove_edges', 'vertex_degree']
+
+    Returns
+    -------
+    out : list of int
+        Cell count (number of simplices) per dimension greater than or equal
+        than `min_dimension` and less than `max_dimension`.
+
+    Notes
+    -----
+    The input graphs cannot contain self-loops, i.e. edges that start and end
+    in the same vertex, therefore diagonal elements of the input adjacency
+    matrix store vertex weights.
+
+    References
+    ----------
+    .. [1] D. Luetgehetmann, "Documentation of the C++ flagser library";
+           `GitHub: luetge/flagser <https://github.com/luetge/flagser/blob/\
+           master/docs/documentation_flagser.pdf>`_.
+
+    """
+    # Handle default parameters
+    if max_dimension == np.inf:
+        _max_dimension = -1
+    else:
+        _max_dimension = max_dimension
+
+    if filtration not in implemented_filtrations:
+        raise ValueError("Filtration not recognized. Available filtrations "
+                         "are ", implemented_filtrations)
+
+    # Extract vertices and edges weights
+    vertices, edges = _extract_weighted_graph(adjacency_matrix,
+                                              max_edge_length)
+
+    # Call flagser_count binding
+    cell_count = compute_cell_count(vertices, edges, min_dimension,
+                                  _max_dimension, directed, filtration)
+
+    return cell_count[min_dimension:]

--- a/pyflagser/flagser_count.py
+++ b/pyflagser/flagser_count.py
@@ -34,8 +34,8 @@ def flagser_count_unweighted(adjacency_matrix, min_dimension=0,
     Returns
     -------
     out : list of int
-        Cell count (number of simplices) per dimension greater than or equal
-        than `min_dimension` and less than `max_dimension`.
+        Cell counts (number of simplices), per dimension greater than or equal
+        to `min_dimension` and less than `max_dimension`.
 
     Notes
     -----
@@ -101,7 +101,7 @@ def flagser_count_weighted(adjacency_matrix, max_edge_weight=None,
     Returns
     -------
     out : list of int
-        Cell count (number of simplices) at filtration value `max_edge_weight`
+        Cell counts (number of simplices) at filtration value `max_edge_weight`,
         per dimension.
 
     Notes

--- a/pyflagser/flagser_count.py
+++ b/pyflagser/flagser_count.py
@@ -93,12 +93,13 @@ def flagser_count_weighted(adjacency_matrix, max_edge_weight=None,
         flag complex determined by `adjacency_matrix`. If ``False``, computes
         persistent homology for the undirected filtered flag complex obtained
         by considering all weighted edges as undirected, and if two directed
-        edges corresponding to the same undirected edge are assigned different
-        weights, only the one on the upper triangular part of the adjacency
-        matrix is considered. Therefore:
+        edges corresponding to the same undirected edge are explicitly assigned
+        different weights and neither exceeds `max_edge_weight`, only the one
+        in the upper triangular part of the adjacency matrix is considered.
+        Therefore:
 
         - if `max_edge_weight` is ``numpy.inf``, it is sufficient to pass a
-          (dense or sparse) upper-triangular matrices;
+          (dense or sparse) upper-triangular matrix;
         - if `max_edge_weight` is finite, it is recommended to pass either a
           symmetric dense matrix, or a sparse upper-triangular matrix.
 

--- a/pyflagser/flagser_count.py
+++ b/pyflagser/flagser_count.py
@@ -90,13 +90,17 @@ def flagser_count_weighted(adjacency_matrix, max_edge_weight=None,
 
     directed : bool, optional, default: ``True``
         If ``True``, computes persistent homology for the directed filtered
-        flag complex determined by `adjacency_matrix`. If False, computes
+        flag complex determined by `adjacency_matrix`. If ``False``, computes
         persistent homology for the undirected filtered flag complex obtained
-        by considering all weighted edges as undirected, and it is therefore
-        sufficient (but not necessary) to pass an upper-triangular matrix. When
-        ``False``, if two directed edges corresponding to the same undirected
-        edge are assigned different weights, only the one on the upper
-        triangular part of the adjacency matrix is considered.
+        by considering all weighted edges as undirected, and if two directed
+        edges corresponding to the same undirected edge are assigned different
+        weights, only the one on the upper triangular part of the adjacency
+        matrix is considered. Therefore:
+
+        - if `max_edge_weight` is ``numpy.inf``, it is sufficient to pass a
+          (dense or sparse) upper-triangular matrices;
+        - if `max_edge_weight` is finite, it is recommended to pass either a
+          symmetric dense matrix, or a sparse upper-triangular matrix.
 
     Returns
     -------

--- a/pyflagser/flagser_count.py
+++ b/pyflagser/flagser_count.py
@@ -13,7 +13,7 @@ def flagser_count_unweighted(adjacency_matrix, min_dimension=0,
     flag complex.
 
     From an adjacency_matrix construct all cells forming its associated flag
-    complex and count their number per dimension.
+    complex and compute their number per dimension.
 
     Parameters
     ----------
@@ -63,7 +63,11 @@ def flagser_count_weighted(adjacency_matrix, max_edge_length=None,
                            min_dimension=0, max_dimension=np.inf,
                            directed=True, filtration="max"):
     """Compute the cell count per dimension of a directed/undirected
-    weighted/unweighted flag complexes.
+    filtered flag complexes.
+
+    From an adjacency_matrix construct a filtered flag complex as a sequence of
+    its cells associated to their filtration values and compute the number of
+    cells per dimension.
 
     Parameters
     ----------

--- a/pyflagser/flagser_count.py
+++ b/pyflagser/flagser_count.py
@@ -25,12 +25,6 @@ def flagser_count_unweighted(adjacency_matrix, min_dimension=0,
         denote abstent edges while non-``0`` or ``True`` values denote edges
         which are present. Diagonal values are ignored.
 
-    min_dimension : int, optional, default: ``0``
-        Minimum cell dimension to count.
-
-    max_dimension : int or np.inf, optional, default: ``np.inf``
-        Maximum cell dimension to count.
-
     directed : bool, optional, default: ``True``
         If ``True``, computes homology for the directed flad complex determined
         by `adjacency_matrix`. If ``False``, computes homology for the
@@ -57,23 +51,13 @@ def flagser_count_unweighted(adjacency_matrix, min_dimension=0,
            master/docs/documentation_flagser.pdf>`_.
 
     """
-    # Handle default parameters
-    if max_dimension == np.inf:
-        _max_dimension = -1
-    else:
-        _max_dimension = max_dimension
-
-    # All edge filtrations are equivalent in the static case
-    _filtration = 'max'
-
     # Extract vertices and edges
     vertices, edges = _extract_unweighted_graph(adjacency_matrix)
 
     # Call flagser_count binding
-    cell_count = compute_cell_count(vertices, edges, min_dimension,
-                                    _max_dimension,  directed, _filtration)
+    cell_count = compute_cell_count(vertices, edges, directed)
 
-    return cell_count[min_dimension:]
+    return cell_count
 
 
 def flagser_count_weighted(adjacency_matrix, max_edge_length=None,
@@ -102,12 +86,6 @@ def flagser_count_weighted(adjacency_matrix, max_edge_length=None,
         infinitely-valued, i.e., absent from the filtration. If ``None``, all
         finite edge weights are considered.
 
-    min_dimension : int, optional, default: ``0``
-        Minimum cell dimension to count.
-
-    max_dimension : int or np.inf, optional, default: ``np.inf``
-        Maximum cell dimension to count.
-
     directed : bool, optional, default: ``True``
         If ``True``, computes persistent homology for the directed filtered
         flag complex determined by `adjacency_matrix`. If False, computes
@@ -118,21 +96,10 @@ def flagser_count_weighted(adjacency_matrix, max_edge_length=None,
         edge are assigned different weights, only the one on the upper
         triangular part of the adjacency matrix is considered.
 
-    filtration : string, optional, default: ``'max'``
-        Algorithm determining the filtration. Warning: if an edge filtration is
-        specified, it is assumed that the resulting filtration is consistent,
-        meaning that the filtration value of every simplex of dimension at
-        least two should evaluate to a value that is at least the maximal value
-        of the filtration values of its containing edges. For performance
-        reasons, this is not checked automatically.  Possible values are:
-        ['dimension', 'zero', 'max', 'max3', 'max_plus_one', 'product', 'sum',
-        'pmean', 'pmoment', 'remove_edges', 'vertex_degree']
-
     Returns
     -------
     out : list of int
-        Cell count (number of simplices) per dimension greater than or equal
-        than `min_dimension` and less than `max_dimension`.
+        Cell count (number of simplices) per dimension.
 
     Notes
     -----
@@ -147,22 +114,11 @@ def flagser_count_weighted(adjacency_matrix, max_edge_length=None,
            master/docs/documentation_flagser.pdf>`_.
 
     """
-    # Handle default parameters
-    if max_dimension == np.inf:
-        _max_dimension = -1
-    else:
-        _max_dimension = max_dimension
-
-    if filtration not in implemented_filtrations:
-        raise ValueError("Filtration not recognized. Available filtrations "
-                         "are ", implemented_filtrations)
-
     # Extract vertices and edges weights
     vertices, edges = _extract_weighted_graph(adjacency_matrix,
                                               max_edge_length)
 
     # Call flagser_count binding
-    cell_count = compute_cell_count(vertices, edges, min_dimension,
-                                  _max_dimension, directed, filtration)
+    cell_count = compute_cell_count(vertices, edges, directed)
 
-    return cell_count[min_dimension:]
+    return cell_count

--- a/pyflagser/flagser_count.py
+++ b/pyflagser/flagser_count.py
@@ -101,7 +101,8 @@ def flagser_count_weighted(adjacency_matrix, max_edge_weight=None,
     Returns
     -------
     out : list of int
-        Cell count (number of simplices) per dimension.
+        Cell count (number of simplices) at filtration value `max_edge_weight`
+        per dimension.
 
     Notes
     -----

--- a/pyflagser/tests/conftest.py
+++ b/pyflagser/tests/conftest.py
@@ -2,7 +2,7 @@ import os
 from tempfile import mkdtemp
 from urllib.request import urlopen, urlretrieve
 
-from flagser_pybind import implemented_filtrations
+from ..modules.flagser_pybind import AVAILABLE_FILTRATIONS
 
 files_with_filtration_results = ["d5.flag"]
 
@@ -54,7 +54,7 @@ def pytest_generate_tests(metafunc):
         webdl = metafunc.config.option.webdl
         FlagFiles.paths = fetch_flag_files(webdl)
     if "filtration" in metafunc.fixturenames:
-        metafunc.parametrize("filtration", implemented_filtrations)
+        metafunc.parametrize("filtration", AVAILABLE_FILTRATIONS)
         paths = [
             path for path in FlagFiles.paths
             if os.path.split(path)[1] in files_with_filtration_results

--- a/pyflagser/tests/test_flagser_count.py
+++ b/pyflagser/tests/test_flagser_count.py
@@ -1,7 +1,6 @@
 """Testing for the python bindings of the C++ flagser library."""
 
 import os
-import numpy as np
 
 from numpy.testing import assert_almost_equal
 

--- a/pyflagser/tests/test_flagser_count.py
+++ b/pyflagser/tests/test_flagser_count.py
@@ -1,0 +1,45 @@
+"""Testing for the python bindings of the C++ flagser library."""
+
+import os
+import numpy as np
+
+from numpy.testing import assert_almost_equal
+
+from pyflagser import load_unweighted_flag, load_weighted_flag, \
+    flagser_count_unweighted, flagser_count_weighted
+
+
+cell_count = {
+    'a.flag': [5, 7, 1],
+    'b.flag': [4, 6, 3],
+    'c.flag': [8, 12],
+    'd.flag': [5, 9, 6],
+    'e.flag': [5, 9, 7, 2],
+    'f.flag': [3, 5, 3],
+    'd2.flag': [2, 2],
+    'd3.flag': [3, 6, 6],
+    'd3-allzero.flag': [3, 6, 6],
+    'double-d3.flag': [4, 10, 12],
+    'double-d3-allzero.flag': [4, 10, 12],
+    'd4.flag': [4, 12, 24, 24],
+    'd4-allzero.flag': [4, 12, 24, 24],
+    'd5.flag': [5, 20, 60, 120, 120],
+    'd7.flag': [7, 42, 210, 840, 2520, 5040, 5040],
+    'medium-test-data.flag': [31346, 68652, 12694, 250],
+    'd10.flag': [10, 90, 720, 5040, 30240, 151200, 604800,
+                 1814400, 3628800, 3628800],
+}
+
+
+def test_unweighted(flag_file):
+    adjacency_matrix = load_unweighted_flag(flag_file, fmt='dense')
+    cell_count_exp = cell_count[os.path.split(flag_file)[1]]
+    cell_count_res = flagser_count_unweighted(adjacency_matrix)
+    assert_almost_equal(cell_count_res, cell_count_exp)
+
+
+def test_weighted(flag_file):
+    adjacency_matrix = load_weighted_flag(flag_file, fmt='coo')
+    cell_count_exp = cell_count[os.path.split(flag_file)[1]]
+    cell_count_res = flagser_count_weighted(adjacency_matrix)
+    assert_almost_equal(cell_count_res, cell_count_exp)

--- a/setup.py
+++ b/setup.py
@@ -102,8 +102,8 @@ class CMakeBuild(build_ext):
                                '--init', '--recursive'])
 
     def build_extension(self, ext):
-        extdir = os.path.abspath(os.path.dirname(
-            self.get_ext_fullpath(ext.name)))
+        extdir = os.path.abspath(os.path.join(os.path.dirname(
+            self.get_ext_fullpath(ext.name)), 'pyflagser', 'modules'))
         cmake_args = ['-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=' + extdir,
                       '-DPYTHON_EXECUTABLE=' + sys.executable]
 

--- a/src/flagser_bindings.cpp
+++ b/src/flagser_bindings.cpp
@@ -115,7 +115,8 @@ PYBIND11_MODULE(flagser_pybind, m) {
     std::cout.rdbuf(nullptr);
 
     // Running flagser's compute_homology routine
-    auto output = compute_homology(graph, named_arguments, max_entries, modulus);
+    auto subgraph_persistence_computer =
+      compute_homology(graph, named_arguments, max_entries, modulus);
 
     // Re-enable again cout
     std::cout.rdbuf(cout_buff);
@@ -124,6 +125,6 @@ PYBIND11_MODULE(flagser_pybind, m) {
     if (remove(named_arguments["out"]) != 0)
       perror("Error deleting flagser output file");
 
-    return output;
+    return subgraph_persistence_computer;
   });
 }

--- a/src/flagser_bindings.cpp
+++ b/src/flagser_bindings.cpp
@@ -1,7 +1,3 @@
-// #define WITH_HDF5
-// #define KEEP_FLAG_COMPLEX_IN_MEMORY
-// #define USE_COEFFICIENTS
-// #define MANY_VERTICES
 #include <stdio.h>
 #include <iostream>
 
@@ -13,27 +9,38 @@
 
 namespace py = pybind11;
 
+
+#ifdef USE_COEFFICIENTS
+PYBIND11_MODULE(flagser_coeff_pybind, m) {
+#else
 PYBIND11_MODULE(flagser_pybind, m) {
-  using persistence_computer_inst =
-      persistence_computer_t<directed_flag_complex_compute_t>;
-  py::class_<persistence_computer_inst>(m, "persistence_computer_t")
+#endif
+
+  m.doc() = "Python interface for flagser";
+
+  m.attr("AVAILABLE_FILTRATIONS") = custom_filtration_computer;
+
+  using PersistenceComputer =
+    persistence_computer_t<directed_flag_complex_compute_t>;
+
+  py::class_<PersistenceComputer>(m, "PersistenceComputer", py::module_local())
       .def("get_euler_characteristic",
-           &persistence_computer_inst::get_euler_characteristic)
+           &PersistenceComputer::get_euler_characteristic)
       .def("get_betti_numbers",
-           py::overload_cast<>(&persistence_computer_inst::get_betti_numbers))
+           py::overload_cast<>(&PersistenceComputer::get_betti_numbers))
       .def("get_betti_numbers",
            py::overload_cast<size_t>(
-               &persistence_computer_inst::get_betti_numbers))
+               &PersistenceComputer::get_betti_numbers))
       .def("get_cell_count",
-           py::overload_cast<>(&persistence_computer_inst::get_cell_count))
+           py::overload_cast<>(&PersistenceComputer::get_cell_count))
       .def("get_cell_count", py::overload_cast<size_t>(
-                                 &persistence_computer_inst::get_cell_count))
+                                 &PersistenceComputer::get_cell_count))
       .def("get_persistence_diagram",
            py::overload_cast<>(
-               &persistence_computer_inst::get_persistence_diagram))
+               &PersistenceComputer::get_persistence_diagram))
       .def("get_persistence_diagram",
            py::overload_cast<size_t>(
-               &persistence_computer_inst::get_persistence_diagram));
+               &PersistenceComputer::get_persistence_diagram));
 
   m.def("compute_homology", [](std::vector<value_t>& vertices,
                                std::vector<std::vector<value_t>>& edges,
@@ -43,58 +50,40 @@ PYBIND11_MODULE(flagser_pybind, m) {
                                std::string filtration) {
     // Save std::cout status
     auto cout_buff = std::cout.rdbuf();
+
+    // flagser's routine needs to be passed command line arguments
     named_arguments_t named_arguments;
-    std::string str_max;
-    std::string str_min;
 
-    HAS_EDGE_FILTRATION has_edge_filtration =
-        HAS_EDGE_FILTRATION::TOO_EARLY_TO_DECIDE;
-
-    // Approximation should only be a positive value
-    // Otherwise it falls back to type::numeric_limits
-    size_t max_entries =
-        approximation >= 0 ? approximation : std::numeric_limits<size_t>::max();
-
-    unsigned short effective_max_dim = max_dim;
-    std::string default_filtration = "max";
-
-    if (max_dim < 0)
-      effective_max_dim = std::numeric_limits<unsigned short>::max();
-
-    str_max = std::to_string(effective_max_dim);
-    str_min = std::to_string(min_dim);
-
-    named_arguments["out"] = "output_flagser_file";
-    named_arguments["max-dim"] = str_max.c_str();
+    // Passing minimum dimension as a command line argument
+    std::string str_min = std::to_string(min_dim);
     named_arguments["min-dim"] = str_min.c_str();
 
-    // Is filtration supported ?
-    if (std::find(custom_filtration_computer.begin(),
-                  custom_filtration_computer.end(),
-                  filtration) == custom_filtration_computer.end()) {
-      std::cout << filtration << " not found, fallback to "
-                << default_filtration << "\n";
-      filtration = default_filtration;
-
-      std::cout << "Implemented filtrations:\n";
-      for (auto& elem : custom_filtration_computer) {
-        if (elem != custom_filtration_computer.back())
-          std::cout << elem << ", ";
-        else
-          std::cout << elem << "\n";
-      }
+    // Passing maximum dimension as a command line argument
+    unsigned short effective_max_dim = max_dim;
+    if (max_dim < 0) {
+      effective_max_dim = std::numeric_limits<unsigned short>::max();
     }
+    std::string str_max = std::to_string(effective_max_dim);
+    named_arguments["max-dim"] = str_max.c_str();
 
+    // Passing filtration as a command line argument
     named_arguments["filtration"] = filtration.c_str();
 
+    // Output file is not used but set to an arbitrary file
+    named_arguments["out"] = "output_flagser_file";
+
+    // Remove output file if already present
     remove(named_arguments["out"]);
 
+    // Building the filtered directed graph
     auto graph = filtered_directed_graph_t(vertices, directed);
 
-    // If we have at least one vertice
+    HAS_EDGE_FILTRATION has_edge_filtration =
+      HAS_EDGE_FILTRATION::TOO_EARLY_TO_DECIDE;
+
+    // If we have at least one edge
     if (edges.size() && has_edge_filtration == HAS_EDGE_FILTRATION::MAYBE) {
-      // If the edge has three components, then there are also
-      // filtration values, which we assume to come last
+      // If the edge has three components, the last is the filtration value
       has_edge_filtration = edges[0].size() == 2 ? HAS_EDGE_FILTRATION::NO
                                                  : HAS_EDGE_FILTRATION::YES;
     }
@@ -118,20 +107,23 @@ PYBIND11_MODULE(flagser_pybind, m) {
       }
     }
 
+    // If approximation is negative it falls back to type::numeric_limits
+    size_t max_entries =
+        approximation >= 0 ? approximation : std::numeric_limits<size_t>::max();
+
+    // Disable cout
     std::cout.rdbuf(nullptr);
 
-    auto ret = compute_homology(graph, named_arguments, max_entries, modulus);
+    // Running flagser's compute_homology routine
+    auto output = compute_homology(graph, named_arguments, max_entries, modulus);
 
+    // Re-enable again cout
+    std::cout.rdbuf(cout_buff);
+
+    // Remove generate output file
     if (remove(named_arguments["out"]) != 0)
       perror("Error deleting flagser output file");
 
-    // re enable again cout
-    std::cout.rdbuf(cout_buff);
-
-    return ret;
+    return output;
   });
-
-  m.attr("implemented_filtrations") = custom_filtration_computer;
-
-  m.doc() = "Python bindings for flagser";
 }

--- a/src/flagser_count_bindings.cpp
+++ b/src/flagser_count_bindings.cpp
@@ -58,11 +58,11 @@ PYBIND11_MODULE(flagser_count_pybind, m) {
     std::cout.rdbuf(nullptr);
 
     // Running flagser-count's count_cells routine
-    auto output = count_cells(graph, named_arguments);
+    auto cell_count = count_cells(graph, named_arguments);
 
     // Re-enable again cout
     std::cout.rdbuf(cout_buff);
 
-    return output;
+    return cell_count;
   });
 }

--- a/src/flagser_count_bindings.cpp
+++ b/src/flagser_count_bindings.cpp
@@ -1,0 +1,107 @@
+// #define WITH_HDF5
+// #define KEEP_FLAG_COMPLEX_IN_MEMORY
+// #define USE_COEFFICIENTS
+// #define MANY_VERTICES
+#include <stdio.h>
+#include <iostream>
+
+#include <flagser/include/argparser.h>
+#include <flagser/src/flagser-count.cpp>
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+namespace py = pybind11;
+
+PYBIND11_MODULE(flagser_count_pybind, m) {
+  m.def("compute_cell_count", [](std::vector<value_t>& vertices,
+                                 std::vector<std::vector<value_t>>& edges,
+                                 unsigned short min_dim, short max_dim,
+                                 bool directed, std::string filtration) {
+    // Save std::cout status
+    auto cout_buff = std::cout.rdbuf();
+    named_arguments_t named_arguments;
+    std::string str_max;
+    std::string str_min;
+
+    HAS_EDGE_FILTRATION has_edge_filtration =
+        HAS_EDGE_FILTRATION::TOO_EARLY_TO_DECIDE;
+
+    unsigned short effective_max_dim = max_dim;
+    std::string default_filtration = "max";
+
+    if (max_dim < 0)
+      effective_max_dim = std::numeric_limits<unsigned short>::max();
+
+    str_max = std::to_string(effective_max_dim);
+    str_min = std::to_string(min_dim);
+
+    named_arguments["out"] = "output_flagser_file";
+    named_arguments["max-dim"] = str_max.c_str();
+    named_arguments["min-dim"] = str_min.c_str();
+
+    // Is filtration supported ?
+    if (std::find(custom_filtration_computer.begin(),
+                  custom_filtration_computer.end(),
+                  filtration) == custom_filtration_computer.end()) {
+      std::cout << filtration << " not found, fallback to "
+                << default_filtration << "\n";
+      filtration = default_filtration;
+
+      std::cout << "Implemented filtrations:\n";
+      for (auto& elem : custom_filtration_computer) {
+        if (elem != custom_filtration_computer.back())
+          std::cout << elem << ", ";
+        else
+          std::cout << elem << "\n";
+      }
+    }
+
+    named_arguments["filtration"] = filtration.c_str();
+
+    remove(named_arguments["out"]);
+
+    auto graph = filtered_directed_graph_t(vertices, directed);
+
+    // If we have at least one vertice
+    if (edges.size() && has_edge_filtration == HAS_EDGE_FILTRATION::MAYBE) {
+      // If the edge has three components, then there are also
+      // filtration values, which we assume to come last
+      has_edge_filtration = edges[0].size() == 2 ? HAS_EDGE_FILTRATION::NO
+                                                 : HAS_EDGE_FILTRATION::YES;
+    }
+
+    for (auto& edge : edges) {
+      if (has_edge_filtration == NO) {
+        graph.add_edge(edge[0], edge[1]);
+      } else {
+        if (edge[2] < std::max(vertices[edge[0]], vertices[edge[1]])) {
+          std::cerr << "The data contains an edge "
+                       "filtration that contradicts the vertex "
+                       "filtration, the edge ("
+                    << edge[0] << ", " << edge[1] << ") has filtration value "
+                    << edge[2] << ", which is lower than min("
+                    << vertices[edge[0]] << ", " << vertices[edge[1]]
+                    << "), the filtrations of its edges.";
+          exit(-1);
+        }
+        graph.add_filtered_edge((vertex_index_t)edge[0],
+                                (vertex_index_t)edge[1], edge[2]);
+      }
+    }
+
+    std::cout.rdbuf(nullptr);
+
+    auto ret = count_cells(graph, named_arguments);
+
+    if (remove(named_arguments["out"]) != 0)
+      perror("Error deleting flagser output file");
+
+    // re enable again cout
+    std::cout.rdbuf(cout_buff);
+
+    return ret;
+  });
+
+  m.doc() = "Python bindings for flagser_count";
+}

--- a/src/flagser_count_bindings.cpp
+++ b/src/flagser_count_bindings.cpp
@@ -16,49 +16,15 @@ namespace py = pybind11;
 PYBIND11_MODULE(flagser_count_pybind, m) {
   m.def("compute_cell_count", [](std::vector<value_t>& vertices,
                                  std::vector<std::vector<value_t>>& edges,
-                                 unsigned short min_dim, short max_dim,
-                                 bool directed, std::string filtration) {
+                                 bool directed) {
     // Save std::cout status
     auto cout_buff = std::cout.rdbuf();
     named_arguments_t named_arguments;
-    std::string str_max;
-    std::string str_min;
 
     HAS_EDGE_FILTRATION has_edge_filtration =
         HAS_EDGE_FILTRATION::TOO_EARLY_TO_DECIDE;
 
-    unsigned short effective_max_dim = max_dim;
-    std::string default_filtration = "max";
-
-    if (max_dim < 0)
-      effective_max_dim = std::numeric_limits<unsigned short>::max();
-
-    str_max = std::to_string(effective_max_dim);
-    str_min = std::to_string(min_dim);
-
     named_arguments["out"] = "output_flagser_file";
-    named_arguments["max-dim"] = str_max.c_str();
-    named_arguments["min-dim"] = str_min.c_str();
-
-    // Is filtration supported ?
-    if (std::find(custom_filtration_computer.begin(),
-                  custom_filtration_computer.end(),
-                  filtration) == custom_filtration_computer.end()) {
-      std::cout << filtration << " not found, fallback to "
-                << default_filtration << "\n";
-      filtration = default_filtration;
-
-      std::cout << "Implemented filtrations:\n";
-      for (auto& elem : custom_filtration_computer) {
-        if (elem != custom_filtration_computer.back())
-          std::cout << elem << ", ";
-        else
-          std::cout << elem << "\n";
-      }
-    }
-
-    named_arguments["filtration"] = filtration.c_str();
-
     remove(named_arguments["out"]);
 
     auto graph = filtered_directed_graph_t(vertices, directed);


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
Due to high demand, `pyflagser` is enabling the direct use of `count_cells` functionalities from C++ `flagser`.

Additionally:
 - Two different versions of flagser are now compiled for coeff = 2 and coeff != 2
 - The pybind11 files have been freshen up and fully commented for maintenance
 - #43 is fixed 

#### Any other comments?
This adds the pybind11 bindings, the python API and the appropriate tests.