### PR TITLE
Support rectangular (esp. sparse) matrices in pyflagser, fixing #48

### DIFF
--- a/pyflagser/_utils.py
+++ b/pyflagser/_utils.py
@@ -1,57 +1,66 @@
 """Utility functions for adjacency matrices."""
 
-import numpy as np
 import warnings
+
+import numpy as np
 
 
 def _extract_unweighted_graph(adjacency_matrix):
-    # Warn if the matrix is not squared
-    if adjacency_matrix.shape[0] != adjacency_matrix.shape[1]:
-        warnings.warn("adjacency_matrix should be a square matrix.")
+    input_shape = adjacency_matrix.shape
+    # Warn if dense and not square
+    if isinstance(adjacency_matrix, np.ndarray) and \
+            (input_shape[0] != input_shape[1]):
+        warnings.warn("Dense `adjacency_matrix` should be square.")
 
     # Extract vertices and give them weight one
-    vertices = np.ones(adjacency_matrix.shape[0], dtype=np.float)
+    n_vertices = max(input_shape)
+    vertices = np.ones(n_vertices, dtype=np.float)
 
-    # Extract edges indices
+    # Extract edge indices
     if isinstance(adjacency_matrix, np.ndarray):
         # Off-diagonal mask
-        mask = np.logical_not(np.eye(adjacency_matrix.shape[0], dtype=bool))
+        mask = np.logical_not(np.eye(input_shape[0], M=input_shape[1],
+                                     dtype=bool))
 
         # Data mask
         mask = np.logical_and(adjacency_matrix, mask)
 
         edges = np.argwhere(mask)
     else:
-        # Data mask
-        mask = np.stack(np.nonzero(adjacency_matrix)).T
+        edges = np.argwhere(adjacency_matrix)
 
-        # Removes diagonal elements a posteriori
-        edges = mask[mask[:, 0] != mask[:, 1]]
+        # Remove diagonal elements a posteriori
+        edges = edges[edges[:, 0] != edges[:, 1]]
 
     # Assign weight one
-    edges = np.hstack([edges, np.ones(edges[:, [0]].shape, dtype=np.int)])
+    edges = np.insert(edges, 2, 1, axis=1)
 
     return vertices, edges
 
 
 def _extract_weighted_graph(adjacency_matrix, max_edge_weight):
-    # Warn if the matrix is not squared
-    if adjacency_matrix.shape[0] != adjacency_matrix.shape[1]:
-        warnings.warn("adjacency_matrix should be a square matrix.")
+    input_shape = adjacency_matrix.shape
+    # Warn if dense and not square
+    if isinstance(adjacency_matrix, np.ndarray) and \
+            (input_shape[0] != input_shape[1]):
+        warnings.warn("Dense `adjacency_matrix` should be square.")
 
-    # Extract vertices weights
-    vertices = np.asarray(adjacency_matrix.diagonal())
+    # Extract vertex weights
+    n_vertices = max(input_shape)
+    vertices = np.zeros(n_vertices, dtype=adjacency_matrix.dtype)
+    vertices[:min(input_shape)] = adjacency_matrix.diagonal()
 
-    # Extract edges indices and weights
+    # Extract edge indices and weights
     if isinstance(adjacency_matrix, np.ndarray):
         row, column = np.indices(adjacency_matrix.shape)
         row, column = row.flat, column.flat
         data = adjacency_matrix.flat
 
         # Off-diagonal mask
-        mask = np.logical_not(np.eye(vertices.shape[0], dtype=bool).flat)
+        mask = np.logical_not(np.eye(input_shape[0], M=input_shape[1],
+                                     dtype=bool).flat)
     else:
-        # Convert to COO format to extract row column, and data arrays
+        # Convert to COO format to extract row, column, and data arrays
         fmt = adjacency_matrix.getformat()
         adjacency_matrix = adjacency_matrix.tocoo()
         row, column = adjacency_matrix.row, adjacency_matrix.col
@@ -59,8 +68,7 @@ def _extract_weighted_graph(adjacency_matrix, max_edge_weight):
         adjacency_matrix = adjacency_matrix.asformat(fmt)
 
         # Off-diagonal mask
-        mask = np.ones(row.shape[0], dtype=np.bool)
-        mask[np.arange(row.shape[0])[row == column]] = False
+        mask = row != column
 
     # Mask infinite or thresholded weights
     if np.issubdtype(adjacency_matrix.dtype, np.float_):
@@ -71,6 +79,6 @@ def _extract_weighted_graph(adjacency_matrix, max_edge_weight):
     elif max_edge_weight is not None:
         mask = np.logical_and(mask, data <= max_edge_weight)
 
-    edges = np.vstack([row[mask], column[mask], data[mask]]).T
+    edges = np.c_[row[mask], column[mask], data[mask]]
 
     return vertices, edges

--- a/pyflagser/flagser.py
+++ b/pyflagser/flagser.py
@@ -21,7 +21,7 @@ def flagser_unweighted(adjacency_matrix, min_dimension=0, max_dimension=np.inf,
         (n_vertices, n_vertices), required
         Adjacency matrix of a directed/undirected unweighted graph. It is
         understood as a boolean matrix. Off-diagonal, ``0`` or ``False`` values
-        denote abstent edges while non-``0`` or ``True`` values denote edges
+        denote absent edges while non-``0`` or ``True`` values denote edges
         which are present. Diagonal values are ignored.
 
     min_dimension : int, optional, default: ``0``
@@ -133,7 +133,7 @@ def flagser_weighted(adjacency_matrix, max_edge_weight=None, min_dimension=0,
         zero values denote zero-weighted edges. If the matrix is a sparse
         ``scipy.sparse`` matrix, explicitly stored off-diagonal zeros and all
         diagonal zeros denote zero-weighted edges. Off-diagonal values that
-        have not been explicitely stored are treated by ``scipy.sparse`` as
+        have not been explicitly stored are treated by ``scipy.sparse`` as
         zeros but will be understood as infinitely-valued edges, i.e., edges
         absent from the filtration.
 


### PR DESCRIPTION
#### Reference Issues/PRs
#48 


#### What does this implement/fix? Explain your changes.
Allows for non-square input in `_extract_unweighted_graph` and `_extract_weighted_graph`, handling all unspecified off-diagonal entries as absent from the filtration. Non-square warnings are left only for dense input. Code is simplified.