### PR TITLE
fix unweighted flag saving crashes

### DIFF
--- a/pyflagser/flagio.py
+++ b/pyflagser/flagio.py
@@ -191,9 +191,8 @@ def save_unweighted_flag(fname, adjacency_matrix):
     vertices, edges = _extract_unweighted_graph(adjacency_matrix)
 
     with open(fname, 'w') as f:
-        np.savetxt(f, vertices, delimiter=' ', comments='', header='dim 0',
-                   fmt='%.18e')
-        np.savetxt(f, edges, comments='', header='dim 1', fmt='%i %i')
+        np.savetxt(f, vertices.reshape((1,-1)), delimiter=' ', header='dim 0', fmt='%i')
+        np.savetxt(f, edges, comments='', header='dim 1', fmt='%i %i %i')
 
 
 def save_weighted_flag(fname, adjacency_matrix, max_edge_weight=None):

--- a/pyflagser/flagio.py
+++ b/pyflagser/flagio.py
@@ -191,7 +191,8 @@ def save_unweighted_flag(fname, adjacency_matrix):
     vertices, edges = _extract_unweighted_graph(adjacency_matrix)
 
     with open(fname, 'w') as f:
-        np.savetxt(f, vertices.reshape((1,-1)), delimiter=' ', header='dim 0', fmt='%i')
+        np.savetxt(f, vertices.reshape((1, -1)), delimiter=' ', header='dim 0',
+                   fmt='%i')
         np.savetxt(f, edges, comments='', header='dim 1', fmt='%i %i %i')
 
 

--- a/pyflagser/tests/test_flagio.py
+++ b/pyflagser/tests/test_flagio.py
@@ -7,7 +7,7 @@ import numpy as np
 from numpy.testing import assert_almost_equal
 
 from pyflagser import load_unweighted_flag, load_weighted_flag, \
-    save_weighted_flag
+    save_weighted_flag, save_unweighted_flag
 from pyflagser._utils import _extract_unweighted_graph, \
     _extract_weighted_graph
 
@@ -31,6 +31,18 @@ def test_weighted(flag_file_small, max_edge_length):
     adjacency_matrix = load_weighted_flag(fname_temp)
     vertices_b, edges_b = _extract_weighted_graph(adjacency_matrix,
                                                   max_edge_length)
+    os.remove(fname_temp)
+    assert_almost_equal(vertices_a, vertices_a)
+    assert_almost_equal(edges_b, edges_b)
+
+
+def test_unweighted(flag_file_small):
+    adjacency_matrix = load_unweighted_flag(flag_file_small)
+    vertices_a, edges_a = _extract_unweighted_graph(adjacency_matrix)
+    fname_temp = os.path.split(flag_file_small)[1]
+    save_unweighted_flag(fname_temp, adjacency_matrix)
+    adjacency_matrix = load_unweighted_flag(fname_temp)
+    vertices_b, edges_b = _extract_unweighted_graph(adjacency_matrix)
     os.remove(fname_temp)
     assert_almost_equal(vertices_a, vertices_a)
     assert_almost_equal(edges_b, edges_b)


### PR DESCRIPTION
Fixes unweighted flag saving as described in issue #58.

See PR #59 for more details. This PR differs only on the branch used on my fork (from `master` to `unweighted_saving_fix`).
