### PR TITLE
added MANY_VERTICES compile flag to enable proper flagsing on graphs …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ set(BINDINGS_DIR "src")
 # flagser
 pybind11_add_module(flagser_pybind "${BINDINGS_DIR}/flagser_bindings.cpp")
 
-target_compile_definitions(flagser_pybind PRIVATE RETRIEVE_PERSISTENCE=1)
+target_compile_definitions(flagser_pybind PRIVATE RETRIEVE_PERSISTENCE=1 MANY_VERTICES=1)
 target_include_directories(flagser_pybind PRIVATE .)
 
 if(MSVC)
@@ -24,7 +24,7 @@ endif()
 # flagser with USE_COEFFICIENTS
 pybind11_add_module(flagser_coeff_pybind "${BINDINGS_DIR}/flagser_bindings.cpp")
 
-target_compile_definitions(flagser_coeff_pybind PRIVATE RETRIEVE_PERSISTENCE=1 USE_COEFFICIENTS=1)
+target_compile_definitions(flagser_coeff_pybind PRIVATE RETRIEVE_PERSISTENCE=1 USE_COEFFICIENTS=1 MANY_VERTICES=1)
 target_include_directories(flagser_coeff_pybind PRIVATE .)
 
 if(MSVC)
@@ -40,6 +40,7 @@ endif()
 pybind11_add_module(flagser_count_pybind "${BINDINGS_DIR}/flagser_count_bindings.cpp")
 
 target_include_directories(flagser_count_pybind PRIVATE .)
+target_compile_definitions(flagser_count_pybind PRIVATE MANY_VERTICES=1)
 
 if(MSVC)
     target_compile_options(flagser_count_pybind PUBLIC $<$<CONFIG:RELEASE>: /Wall /O2>)

--- a/pyflagser/tests/test_flagser.py
+++ b/pyflagser/tests/test_flagser.py
@@ -246,3 +246,10 @@ def test_higher_coefficients():
     x = np.random.random((5, 5))
     np.fill_diagonal(x, 0.)
     flagser_weighted(x, coeff=3)
+
+
+def test_really_huge_graphs():
+    """Regression test for issue #65"""
+    from scipy.sparse import coo_matrix
+    x = coo_matrix(([1], ([0], [1])), shape=(2**16, 2**16))
+    flagser_unweighted(x)


### PR DESCRIPTION
…with more than 2^16 vertices. Added regression test.


#### Reference Issues/PRs
(temporarily) fixes Issue #65. 

#### What does this implement/fix? Explain your changes.
flagser is now compiled with MANY_VERTICES.
regression test was added.

Introduces small performance regression (+7% more memory consumption). Is slightly faster. 
Does not crash or produce wrong results for graphs with more than 2^16 vertices..

#### Any other comments?
See Issue #65 
