### PR TITLE
Enable in memory option in C++ backend

### DIFF
--- a/pyflagser/flagser.py
+++ b/pyflagser/flagser.py
@@ -9,7 +9,8 @@ from .modules.flagser_coeff_pybind import compute_homology as \
 
 
 def flagser_unweighted(adjacency_matrix, min_dimension=0, max_dimension=np.inf,
-                       directed=True, coeff=2, approximation=None):
+                       directed=True, coeff=2, approximation=None,
+                       in_memory=False):
     """Compute homology of a directed/undirected flag complex.
 
     From an adjacency_matrix construct all cells forming its associated flag
@@ -47,6 +48,11 @@ def flagser_unweighted(adjacency_matrix, min_dimension=0, max_dimension=np.inf,
         often ``100,000``. Increase for higher precision, decrease for faster
         computation. If ``None``, no approximation is made and all cells are
         used. For more details, please refer to [1]_.
+
+    in_memory: bool, optional, default: ``False``
+        If ``True`` increase memory consumption by speeding up computation.
+        Enable an efficient lookup in the data structure instead of relying on
+        hashing for looking up indices of simplices.
 
     Returns
     -------
@@ -101,7 +107,7 @@ def flagser_unweighted(adjacency_matrix, min_dimension=0, max_dimension=np.inf,
     # Call flagser binding
     homology = _compute_homology(vertices, edges, min_dimension,
                                  _max_dimension, directed, coeff,
-                                 _approximation, _filtration)[0]
+                                 _approximation, _filtration, in_memory)[0]
 
     # Creating dictionary of return values
     out = {
@@ -114,7 +120,7 @@ def flagser_unweighted(adjacency_matrix, min_dimension=0, max_dimension=np.inf,
 
 def flagser_weighted(adjacency_matrix, max_edge_weight=None, min_dimension=0,
                      max_dimension=np.inf, directed=True, filtration="max",
-                     coeff=2, approximation=None):
+                     coeff=2, approximation=None, in_memory=False):
     """Compute persistent homology of a directed/undirected filtered flag
     complex.
 
@@ -184,6 +190,11 @@ def flagser_weighted(adjacency_matrix, max_edge_weight=None, min_dimension=0,
         computation. If ``None``, no approximation is made and all cells are
         used. For more details, please refer to [1]_.
 
+    in_memory: bool, optional, default: ``False``
+        If ``True`` increase memory consumption by speeding up computation.
+        Enable an efficient lookup in the data structure instead of relying on
+        hashing for looking up indices of simplices.
+
     Returns
     -------
     out : dict of list
@@ -247,7 +258,7 @@ def flagser_weighted(adjacency_matrix, max_edge_weight=None, min_dimension=0,
     # Call flagser binding
     homology = _compute_homology(vertices, edges, min_dimension,
                                  _max_dimension, directed, coeff,
-                                 _approximation, filtration)[0]
+                                 _approximation, filtration, in_memory)[0]
 
     # Create dictionary of return values
     out = {


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/giotto-ai/pyflagser/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#61 

#### What does this implement/fix? Explain your changes.

This PR integrates latest changes from `flagser` backend. In which the option `in_memory` is now available when computing homology.
This options allows a tradeoff of using more memory in order to speed up computation.

#### Any other comments?

In order to support the `in_memory` data structure, I needed to duplicate `persistence_computer_t` part that manages the part to retrieve results. In my opinion it's not the best way of doing this, but due to how retrieving values from results was implemented in `flagser` I cannot see how to do differently.
If anyone has a better solution/approach, please let me know !

<!--
We value all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->

Quoting the author:

> The main difference between memory and non-memory is that you can have an efficient lookup in the data structure instead of relying on hashing for looking up indices of simplices. Depending on the use case, this can have huge performance differences, either in terms of compute time or memory, so choosing the appropriate version is important.
