### PR TITLE
fix save_unweighted_flag by removing the leading '#' in the first line

### DIFF
--- a/pyflagser/flagio.py
+++ b/pyflagser/flagio.py
@@ -192,7 +192,7 @@ def save_unweighted_flag(fname, adjacency_matrix):
 
     with open(fname, 'w') as f:
         np.savetxt(f, vertices.reshape((1, -1)), delimiter=' ', comments='', 
-                header='dim 0', fmt='%i')
+                   header='dim 0', fmt='%i')
         np.savetxt(f, edges, comments='', header='dim 1', fmt='%i %i %i')
 
 

--- a/pyflagser/flagio.py
+++ b/pyflagser/flagio.py
@@ -191,8 +191,8 @@ def save_unweighted_flag(fname, adjacency_matrix):
     vertices, edges = _extract_unweighted_graph(adjacency_matrix)
 
     with open(fname, 'w') as f:
-        np.savetxt(f, vertices.reshape((1, -1)), delimiter=' ', header='dim 0',
-                   fmt='%i')
+        np.savetxt(f, vertices.reshape((1, -1)), delimiter=' ', comments='', 
+                header='dim 0', fmt='%i')
         np.savetxt(f, edges, comments='', header='dim 1', fmt='%i %i %i')
 
 


### PR DESCRIPTION
Currently the first line of a saved unweighted flag reads '# dim 0' whereas `flagser` strictly expects 'dim 0'.

#### What does this implement/fix? Explain your changes.
Adding the `comments=''` paramenter to np.save fixes this. This is done analogously to `save_weighted_flag`

#### Any other comments?
We did not observe this error before as `load_unweighted_flag` ignores the first line and does not strictly check if it is `dim 0`.
One could "fix" that as well?