### PR TITLE
Fix README in CI and use delvewheel to repair Windows wheels

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -23,8 +23,11 @@ jobs:
           CIBW_BUILD: "cp37-* cp38-* cp39-* cp310-*"
           # Skip 32 bit architectures, musllinux, and i686, and macOS x86_64 wheels for CP3.8 -- CP3.10
           CIBW_SKIP: "*-win32 *-musllinux_x86_64 *_i686 cp38-macosx_x86_64 cp39-macosx_x86_64 cp310-macosx_x86_64"
-          CIBW_BEFORE_BUILD: python -m pip install cmake && python -m pip install --upgrade pip
+          CIBW_BEFORE_BUILD_WINDOWS: python -m pip install cmake && python -m pip install --upgrade pip setuptools && sed -i $'s/\r$//' README.rst && python -m pip install delvewheel
+          CIBW_BEFORE_BUILD_LINUX: python -m pip install cmake && python -m pip install --upgrade pip setuptools
+          CIBW_BEFORE_BUILD_MACOS: python -m pip install cmake && python -m pip install --upgrade pip setuptools
           CIBW_TEST_COMMAND: python -m pyflagser.tests --webdl
+          CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair -w {dest_dir} {wheel}"
           CIBW_TEST_REQUIRES: pytest hypothesis
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           # Should generate universal2 wheels for CP3.8 -- CP3.10

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -27,7 +27,7 @@ jobs:
           CIBW_BEFORE_BUILD_LINUX: python -m pip install cmake && python -m pip install --upgrade pip setuptools
           CIBW_BEFORE_BUILD_MACOS: python -m pip install cmake && python -m pip install --upgrade pip setuptools
           CIBW_TEST_COMMAND: python -m pyflagser.tests --webdl
-          CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair -w {dest_dir} {wheel}"
+          CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair -vv -w {dest_dir} {wheel}"
           CIBW_TEST_REQUIRES: pytest hypothesis
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           # Should generate universal2 wheels for CP3.8 -- CP3.10


### PR DESCRIPTION
Current wheels do not pass `twine check` (and thus cannot be uploaded to PyPI) because the README needs to be fixed in Windows.  In `giotto-tda` for instance, we run `sed -i $'s/\r$//' README.rst` to achieve this.

In this PR, I am introducing this fix as part of the `CIBW_BEFORE_BUILD_WINDOWS` option.

In addition, I propose repairing Windows wheels using `delvewheel`, as suggested in https://cibuildwheel.readthedocs.io/en/stable/options/#repair-wheel-command (even though it is slightly experimental).