### PR TITLE
Add support for building Python 3.11 wheels

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -20,7 +20,7 @@ jobs:
         env:
           # Specify which Python versions to build wheels
           # https://cibuildwheel.readthedocs.io/en/stable/options/#build-skip
-          CIBW_BUILD: "cp37-* cp38-* cp39-* cp310-* cp311-*"
+          CIBW_BUILD: "cp38-* cp39-* cp310-* cp311-*  cp312-*"
           # Skip 32 bit architectures, musllinux, and i686, and macOS x86_64 wheels for CP3.8 -- CP3.11
           CIBW_SKIP: "*-win32 *-musllinux_x86_64 *_i686 cp38-macosx_x86_64 cp39-macosx_x86_64 cp310-macosx_x86_64 cp311-macosx_x86_64"
           CIBW_BEFORE_BUILD_WINDOWS: python -m pip install cmake && python -m pip install --upgrade pip setuptools && sed -i $'s/\r$//' README.rst && python -m pip install delvewheel

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -21,8 +21,8 @@ jobs:
           # Specify which Python versions to build wheels
           # https://cibuildwheel.readthedocs.io/en/stable/options/#build-skip
           CIBW_BUILD: "cp38-* cp39-* cp310-* cp311-*  cp312-*"
-          # Skip 32 bit architectures, musllinux, and i686, and macOS x86_64 wheels for CP3.8 -- CP3.11
-          CIBW_SKIP: "*-win32 *-musllinux_x86_64 *_i686 cp38-macosx_x86_64 cp39-macosx_x86_64 cp310-macosx_x86_64 cp311-macosx_x86_64"
+          # Skip 32 bit architectures, musllinux, and i686, and macOS x86_64 wheels for CP3.8 -- CP3.12
+          CIBW_SKIP: "*-win32 *-musllinux_x86_64 *_i686 cp38-macosx_x86_64 cp39-macosx_x86_64 cp310-macosx_x86_64 cp311-macosx_x86_64 cp312-macosx_x86_64"
           CIBW_BEFORE_BUILD_WINDOWS: python -m pip install cmake && python -m pip install --upgrade pip setuptools && sed -i $'s/\r$//' README.rst && python -m pip install delvewheel
           CIBW_BEFORE_BUILD_LINUX: python -m pip install cmake && python -m pip install --upgrade pip setuptools
           CIBW_BEFORE_BUILD_MACOS: python -m pip install cmake && python -m pip install --upgrade pip setuptools

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -20,9 +20,9 @@ jobs:
         env:
           # Specify which Python versions to build wheels
           # https://cibuildwheel.readthedocs.io/en/stable/options/#build-skip
-          CIBW_BUILD: "cp37-* cp38-* cp39-* cp310-*"
-          # Skip 32 bit architectures, musllinux, and i686, and macOS x86_64 wheels for CP3.8 -- CP3.10
-          CIBW_SKIP: "*-win32 *-musllinux_x86_64 *_i686 cp38-macosx_x86_64 cp39-macosx_x86_64 cp310-macosx_x86_64"
+          CIBW_BUILD: "cp37-* cp38-* cp39-* cp310-* cp311-*"
+          # Skip 32 bit architectures, musllinux, and i686, and macOS x86_64 wheels for CP3.8 -- CP3.11
+          CIBW_SKIP: "*-win32 *-musllinux_x86_64 *_i686 cp38-macosx_x86_64 cp39-macosx_x86_64 cp310-macosx_x86_64 cp311-macosx_x86_64"
           CIBW_BEFORE_BUILD_WINDOWS: python -m pip install cmake && python -m pip install --upgrade pip setuptools && sed -i $'s/\r$//' README.rst && python -m pip install delvewheel
           CIBW_BEFORE_BUILD_LINUX: python -m pip install cmake && python -m pip install --upgrade pip setuptools
           CIBW_BEFORE_BUILD_MACOS: python -m pip install cmake && python -m pip install --upgrade pip setuptools
@@ -30,7 +30,7 @@ jobs:
           CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair -vv -w {dest_dir} {wheel}"
           CIBW_TEST_REQUIRES: pytest hypothesis
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
-          # Should generate universal2 wheels for CP3.8 -- CP3.10
+          # Should generate universal2 wheels for CP3.8 -- CP3.11
           CIBW_ARCHS_MACOS: x86_64 universal2
 
       - uses: actions/upload-artifact@v2


### PR DESCRIPTION
Description:

 • Updated CIBW_BUILD to include cp311-* for Python 3.11.
 • Updated comments in wheels workflow