### PR TITLE
Replaced deprecated pkg_resources dependency with packaging.version

### DIFF
--- a/TestingExpectedComparisons.py
+++ b/TestingExpectedComparisons.py
@@ -1,0 +1,12 @@
+from packaging.version import parse
+
+tests = [
+    ("1.2.3", "2.0.0"),
+    ("1.0rc1", "1.0"),
+    ("1.0", "1.0"),
+    ("2.0", "1.9.9"),
+    ("1.0.post1", "1.0"),
+]
+
+for a, b in tests:
+    print(a, "<", b, "=>", parse(a) < parse(b))

--- a/pyflagser/flagser.py
+++ b/pyflagser/flagser.py
@@ -6,6 +6,9 @@ from ._utils import _extract_unweighted_graph, _extract_weighted_graph
 from .modules.flagser_pybind import compute_homology, AVAILABLE_FILTRATIONS
 from .modules.flagser_coeff_pybind import compute_homology as \
     compute_homology_coeff
+#from .flagser_pybind import compute_homology, AVAILABLE_FILTRATIONS
+#from .flagser_coeff_pybind import compute_homology as \
+#    compute_homology_coeff
 
 
 def flagser_unweighted(adjacency_matrix, min_dimension=0, max_dimension=np.inf,

--- a/pyflagser/flagser_count.py
+++ b/pyflagser/flagser_count.py
@@ -3,6 +3,7 @@ library."""
 
 from ._utils import _extract_unweighted_graph, _extract_weighted_graph
 from .modules.flagser_count_pybind import compute_cell_count
+#from .flagser_count_pybind import compute_cell_count
 
 
 def flagser_count_unweighted(adjacency_matrix, directed=True):

--- a/pyflagser/tests/TestingExpectedComparisons.py
+++ b/pyflagser/tests/TestingExpectedComparisons.py
@@ -1,0 +1,12 @@
+from packaging.version import parse
+
+tests = [
+    ("1.2.3", "2.0.0"),
+    ("1.0rc1", "1.0"),
+    ("1.0", "1.0"),
+    ("2.0", "1.9.9"),
+    ("1.0.post1", "1.0"),
+]
+
+for a, b in tests:
+    print(a, "<", b, "=>", parse(a) < parse(b))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+requires = [
+	"setuptools",
+	"wheel",
+	"cmake",
+	"pybind11",
+]
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-description-file = README.rst
+description_file = README.rst
 
 [tool:pytest]
 junit_family=xunit1

--- a/setup.py
+++ b/setup.py
@@ -8,10 +8,11 @@ import sys
 import platform
 import subprocess
 
-from pkg_resources.extern.packaging import version
+from packaging.version import Version
+from packaging.version import parse
+#from pkg_resources.extern.packaging import version
 from setuptools import setup, Extension, find_packages
 from setuptools.command.build_ext import build_ext
-
 
 PACKAGE_DIR = "pyflagser"
 
@@ -83,9 +84,9 @@ class CMakeBuild(build_ext):
                                " , ".join(e.name for e in self.extensions))
 
         if platform.system() == "Windows":
-            cmake_version = version.parse(re.search(r'version\s*([\d.]+)',
+            cmake_version = parse(re.search(r'version\s*([\d.]+)',
                                                     out.decode()).group(1))
-            if cmake_version < version.parse("3.1.0"):
+            if cmake_version < parse("3.1.0"):
                 raise RuntimeError("CMake >= 3.1.0 is required on Windows")
 
         self.install_dependencies()

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,6 @@ import subprocess
 
 from packaging.version import Version
 from packaging.version import parse
-#from pkg_resources.extern.packaging import version
 from setuptools import setup, Extension, find_packages
 from setuptools.command.build_ext import build_ext
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/giotto-ai/pyflagser/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
None
-->


#### What does this implement/fix? Explain your changes.
pkg_resources was removed from setuptools in version 81.0.0 (current version is 82.0.0). Packaging.version, specifically its parse() method, provides equivalent functionality, and as such the former dependency of pkg_resources was replaced with packaging.version.

Additional changes: 
- Added pyproject.toml (modern build metadata)
- Fixed package layout so compiled extensions install correctly (modules/__init__.py)


#### Any other comments?
Tests performed:
-  Built package from source
- Verified C++ extensions compile
- Installed wheel successfully
- Verified `import pyflagser` succeeds
-->
